### PR TITLE
improved error handling in clair.ProcessNotifications

### DIFF
--- a/clair/clair_test.go
+++ b/clair/clair_test.go
@@ -1,0 +1,128 @@
+package clair
+
+import (
+	"fmt"
+	"testing"
+	"net/http"
+	"net/http/httptest"
+	"errors"
+)
+
+var page1 = `{
+	"Notification": {
+		"NextPage": "page2",
+		"New": {
+			"Vulnerability": {
+				"Name": "vnew",
+				"NamespaceName": "namespace1",
+				"Severity": "critical"
+			},
+			"LayersIntroducingVulnerability": ["layer1", "layer2", "layer3"]
+		},
+		"Old": {
+			"Vulnerability": {
+				"Name": "vnew",
+				"NamespaceName": "namespace1",
+				"Severity": "critical"
+			},
+			"LayersIntroducingVulnerability": ["layer1", "layer2", "layer3"]
+		}
+	}
+}`
+
+var page2 = `{
+	"Notification": {
+		"NextPage": "page3",
+		"New": {
+			"Vulnerability": {
+				"Name": "vnew",
+				"NamespaceName": "namespace1",
+				"Severity": "critical"
+			},
+			"LayersIntroducingVulnerability": ["BOOM!", "layer2", "layer3"]
+		},
+		"Old": {
+			"Vulnerability": {
+				"Name": "vnew",
+				"NamespaceName": "namespace1",
+				"Severity": "critical"
+			},
+			"LayersIntroducingVulnerability": ["layer1", "layer2", "layer3"]
+		}
+	}
+}`
+
+var page3 = `{
+	"Notification": {
+		"NextPage": "",
+		"New": {
+			"Vulnerability": {
+				"Name": "vnew",
+				"NamespaceName": "namespace1",
+				"Severity": "critical"
+			},
+			"LayersIntroducingVulnerability": ["layer1", "layer2", "layer3"]
+		},
+		"Old": {
+			"Vulnerability": {
+				"Name": "vnew",
+				"NamespaceName": "namespace1",
+				"Severity": "critical"
+			},
+			"LayersIntroducingVulnerability": ["layer1", "layer2", "layer3"]
+		}
+	}
+}`
+
+var pages = map[string]string {
+	"": page1,
+	"page2": page2,
+	"page3": page3,
+}
+
+func TestProcessNotification(t *testing.T) {
+	fmt.Println("testing")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryValues := r.URL.Query()
+		page := ""
+		if pageVals, ok := queryValues["page"]; ok && len(pageVals) > 0 {
+			page = pageVals[0]
+		}
+		fmt.Fprintln(w, pages[page])
+	}))
+
+	var err error
+	nPagesProcessed := 0
+
+	var robustPageProcessor = func(newLayers, oldLayers []string) error {
+		nPagesProcessed += 1
+		return nil
+	}
+
+	err = ProcessNotification(server.URL, "notificationName", robustPageProcessor)
+	if err != nil {
+		t.Error("there should be no error")
+	}
+	if nPagesProcessed != 3 {
+		t.Error("all 3 pages should be processed")
+	}
+
+	nPagesProcessed = 0
+
+	var failingPageProcessor = func(newLayers, oldLayers []string) error {
+		nPagesProcessed += 1
+		if len(newLayers) > 0 && newLayers[0] == "BOOM!" {
+			return errors.New("bad error")
+		}
+		return nil
+	}
+	
+	err = ProcessNotification(server.URL, "notificationName", failingPageProcessor)
+	if err == nil {
+		t.Error("an error should be reported")
+	}
+	if nPagesProcessed != 3 {
+		t.Errorf("all 3 pages should be processed, but only %d were", nPagesProcessed)
+	}
+}

--- a/cmd/sender/main.go
+++ b/cmd/sender/main.go
@@ -56,10 +56,12 @@ func main() {
 				// send the raw notification details to the SNS notifcation
 				details, err := clair.GetLayer(clairUrl, layer)
 				if err != nil {
+					log.Printf("error getting layer clairUrl=%v, layer=%v, err=%v", clairUrl, layer, err)
 					return err
 				}
 
 				if err := queue.SendNotification(svc, snsTopicArn, details); err != nil {
+					log.Printf("error sending notification err=%v", err)
 					return err
 				}
 


### PR DESCRIPTION
trying to fix issue #8 https://github.com/zalando/clair-sqs/issues/8

the changes are related to the function clair.ProcessNotification, and attempt to fix the following things:
- when pageProcessor fails the following pages are not processed
- defer Body.Close() is repeatedly called - factored the code out into a function so the close is called before another connection is opened
- added some more logging

added a unit test